### PR TITLE
fix (#14589): Pass quasar.config build.sourcemap to vite

### DIFF
--- a/app-vite/lib/config-tools.js
+++ b/app-vite/lib/config-tools.js
@@ -117,9 +117,7 @@ function createViteConfig (quasarConf, quasarRunMode) {
       polyfillModulePreload: build.polyfillModulePreload,
       emptyOutDir: false,
       minify: build.minify,
-      sourcemap: build.sourcemap === true
-        ? 'inline'
-        : build.sourcemap || false
+      sourcemap: build.sourcemap ?? false
     },
 
     optimizeDeps: {


### PR DESCRIPTION
<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [X] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications: -->
For existing consumers setting sourcemap:true, source maps will now be created as separate files instead of inline. Although this is a change in behaviour, this brings it inline with both Quasar and Vite documentation on the topic.

Please see #14589 for analysis behind this change

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app - N/A
- [ ] It's been tested on an Electron app. - N/A
- [X] Any necessary documentation has been added or updated [in the docs] - N/A since we bring inline with docs (https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
I don't know how to local build quasar and test so I have *not* tested this change